### PR TITLE
Fix: Prevent SSH command injection vulnerability

### DIFF
--- a/main.py
+++ b/main.py
@@ -278,7 +278,10 @@ class PfSenseConnectionManager:
             "interface.list": "pfSsh.php playback listinterfaces"
         }
         
-        shell_cmd = shell_commands.get(command, command)
+        shell_cmd = shell_commands.get(command)
+        if shell_cmd is None:
+            logger.error(f"Attempted to execute unknown SSH command: {command}")
+            raise ValueError(f"Unsupported SSH command: {command}")
         
         # Execute via SSH (simplified for example)
         client = paramiko.SSHClient()

--- a/test_mcp.py
+++ b/test_mcp.py
@@ -3,8 +3,52 @@
 
 import asyncio
 import json
-from main import MCPServer, MCPRequest, SecurityContext, AccessLevel
+import os
+from unittest.mock import patch, MagicMock
+from main import MCPServer, MCPRequest, SecurityContext, AccessLevel, PfSenseConnectionManager
 from datetime import datetime
+
+
+async def test_ssh_command_injection_vulnerability():
+    print("\n4. Testing SSH Command Injection Vulnerability...")
+    original_conn_method = os.environ.get("PFSENSE_CONNECTION_METHOD")
+    try:
+        with patch('main.paramiko.SSHClient') as mock_ssh_client_constructor:
+            mock_ssh_instance = MagicMock()
+            mock_ssh_client_constructor.return_value = mock_ssh_instance
+
+            os.environ["PFSENSE_CONNECTION_METHOD"] = "ssh"
+            # Ensure necessary SSH config env vars are set to avoid other errors
+            # if the manager tried to connect before our intended check.
+            os.environ["PFSENSE_SSH_HOST"] = "dummy_host"
+            os.environ["PFSENSE_SSH_USERNAME"] = "dummy_user"
+            os.environ["PFSENSE_SSH_PASSWORD"] = "dummy_pass" # For non-key auth path
+
+            manager = PfSenseConnectionManager()
+
+            try:
+                await manager.execute("this_is_an_invalid_command_exploit")
+                assert False, "ValueError was not raised for invalid SSH command"
+            except ValueError as e:
+                print(f"✅ Caught expected ValueError for invalid command: {e}")
+                assert "Unsupported SSH command" in str(e)
+            except Exception as e:
+                assert False, f"An unexpected exception was raised: {e}"
+
+            mock_ssh_instance.connect.assert_not_called()
+            mock_ssh_instance.exec_command.assert_not_called()
+            print("✅ SSH client methods (connect, exec_command) not called for invalid command.")
+
+    finally:
+        if original_conn_method is None:
+            del os.environ["PFSENSE_CONNECTION_METHOD"]
+        else:
+            os.environ["PFSENSE_CONNECTION_METHOD"] = original_conn_method
+        # Clean up dummy env vars
+        for var in ["PFSENSE_SSH_HOST", "PFSENSE_SSH_USERNAME", "PFSENSE_SSH_PASSWORD"]:
+            if f"dummy_{var}" in os.environ: # Check if we set them
+                 del os.environ[var]
+
 
 async def test():
     print("Testing pfSense MCP Server...")
@@ -32,6 +76,8 @@ async def test():
     print("\n3. Testing prompt processing...")
     result = await server.process_prompt("Show me the system status", context)
     print(f"✅ Prompt processed: {result['tool']}")
+
+    await test_ssh_command_injection_vulnerability()
     
     print("\n✨ All tests passed!")
 


### PR DESCRIPTION
Addresses a critical vulnerability where the _execute_ssh method in PfSenseConnectionManager could execute arbitrary commands if the provided command string was not found in the predefined shell_commands map.

The fix ensures that only commands explicitly defined in the shell_commands dictionary can be executed. If an unknown command is provided, a ValueError is raised, and an error is logged.

A unit test has been added to test_mcp.py to verify that:
1. Attempts to execute an unsupported SSH command raise a ValueError.
2. The underlying SSH client's connect and exec_command methods are not called when an unsupported command is attempted.

This change hardens the security of the SSH connection method.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error handling for unsupported SSH commands, ensuring that invalid commands now raise an explicit error rather than being executed.
- **Tests**
	- Added a new test to verify that unsupported SSH commands are properly rejected and not executed, enhancing security and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->