### PR TITLE
Fix API endpoint paths and add stdio mode support

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -1008,12 +1008,17 @@ async def test_enhanced_connection() -> Dict:
 
 # Main execution
 if __name__ == "__main__":
-    import uvicorn
-    
-    # Run the Enhanced FastMCP server
-    uvicorn.run(
-        "main_enhanced_mcp:mcp",
-        host=os.getenv("MCP_HOST", "0.0.0.0"),
-        port=int(os.getenv("MCP_PORT", "8000")),
-        reload=os.getenv("DEBUG", "false").lower() == "true"
-    )
+    mcp_mode = os.getenv("MCP_MODE", "stdio").lower()
+
+    if mcp_mode == "stdio":
+        # Run in stdio mode for Claude Code MCP integration
+        mcp.run(transport="stdio")
+    else:
+        # Run as HTTP server for standalone/testing
+        import uvicorn
+        uvicorn.run(
+            "main:mcp",
+            host=os.getenv("MCP_HOST", "0.0.0.0"),
+            port=int(os.getenv("MCP_PORT", "8000")),
+            reload=os.getenv("DEBUG", "false").lower() == "true"
+        )

--- a/src/pfsense_api_enhanced.py
+++ b/src/pfsense_api_enhanced.py
@@ -324,7 +324,7 @@ class EnhancedPfSenseAPIClient:
     
     async def get_rules_sorted_by_priority(self, interface: Optional[str] = None) -> Dict:
         """Get rules sorted by their order/priority"""
-        sort = SortOptions(sort_by="sequence", sort_order="asc")
+        sort = SortOptions(sort_by="sequence", sort_order="SORT_ASC")
         return await self.get_firewall_rules(interface=interface, sort=sort)
     
     async def create_firewall_rule(
@@ -482,18 +482,18 @@ class EnhancedPfSenseAPIClient:
         pagination = PaginationOptions(limit=lines)
         
         return await self.get_firewall_logs(
-            filters=filters, 
-            sort=SortOptions(sort_by="timestamp", sort_order="desc"),
+            filters=filters,
+            sort=SortOptions(sort_by="timestamp", sort_order="SORT_DESC"),
             lines=lines
         )
-    
+
     async def get_blocked_traffic_logs(self, lines: int = 100) -> Dict:
         """Get logs of blocked traffic"""
         filters = [QueryFilter("action", "block")]
-        
+
         return await self.get_firewall_logs(
             filters=filters,
-            sort=SortOptions(sort_by="timestamp", sort_order="desc"),
+            sort=SortOptions(sort_by="timestamp", sort_order="SORT_DESC"),
             lines=lines
         )
     
@@ -553,7 +553,7 @@ class EnhancedPfSenseAPIClient:
     async def get_active_leases(self) -> Dict:
         """Get only active DHCP leases"""
         filters = [QueryFilter("state", "active")]
-        sort = SortOptions(sort_by="start", sort_order="desc")
+        sort = SortOptions(sort_by="start", sort_order="SORT_DESC")
         return await self.get_dhcp_leases(filters=filters, sort=sort)
     
     # Object ID Management

--- a/src/pfsense_api_enhanced.py
+++ b/src/pfsense_api_enhanced.py
@@ -43,9 +43,9 @@ class QueryFilter:
 class SortOptions:
     """Represents sorting options for API requests"""
     sort_by: Optional[str] = None
-    sort_order: str = "asc"  # asc, desc
+    sort_order: str = "SORT_ASC"  # SORT_ASC, SORT_DESC (per pfSense API v2 docs)
     reverse: bool = False
-    
+
     def to_params(self) -> Dict[str, str]:
         """Convert to URL parameters"""
         params = {}
@@ -271,7 +271,7 @@ class EnhancedPfSenseAPIClient:
     ) -> Dict:
         """Get interfaces with advanced filtering and sorting"""
         return await self._make_request(
-            "GET", "/status/interface",
+            "GET", "/status/interfaces",
             filters=filters, sort=sort, pagination=pagination
         )
     
@@ -303,7 +303,7 @@ class EnhancedPfSenseAPIClient:
             filters.append(QueryFilter("interface", interface))
         
         return await self._make_request(
-            "GET", "/firewall/rule",
+            "GET", "/firewall/rules",
             filters=filters, sort=sort, pagination=pagination
         )
     
@@ -402,7 +402,7 @@ class EnhancedPfSenseAPIClient:
             filters.append(QueryFilter("type", alias_type))
         
         return await self._make_request(
-            "GET", "/firewall/alias",
+            "GET", "/firewall/aliases",
             filters=filters, sort=sort, pagination=pagination
         )
     
@@ -470,9 +470,9 @@ class EnhancedPfSenseAPIClient:
     ) -> Dict:
         """Get firewall logs with filtering"""
         pagination = PaginationOptions(limit=lines)
-        
+
         return await self._make_request(
-            "GET", "/diagnostics/log/firewall",
+            "GET", "/status/logs/firewall",
             filters=filters, sort=sort, pagination=pagination
         )
     
@@ -506,7 +506,7 @@ class EnhancedPfSenseAPIClient:
     ) -> Dict:
         """Get services with filtering"""
         return await self._make_request(
-            "GET", "/services",
+            "GET", "/status/services",
             filters=filters, sort=sort
         )
     
@@ -534,9 +534,9 @@ class EnhancedPfSenseAPIClient:
             filters = [QueryFilter("interface", interface)]
         elif interface and filters:
             filters.append(QueryFilter("interface", interface))
-        
+
         return await self._make_request(
-            "GET", "/services/dhcpd/lease",
+            "GET", "/status/dhcp_server/leases",
             filters=filters, sort=sort, pagination=pagination
         )
     
@@ -662,7 +662,7 @@ def create_default_sort(field: str, descending: bool = False) -> SortOptions:
     """Create default sort options"""
     return SortOptions(
         sort_by=field,
-        sort_order="desc" if descending else "asc"
+        sort_order="SORT_DESC" if descending else "SORT_ASC"
     )
 
 


### PR DESCRIPTION
## Summary

This PR fixes several issues discovered while testing with pfSense CE 2.8.1 and the pfSense REST API v2 package:

### API Endpoint Path Fixes

The following endpoints were using incorrect paths that don't match the pfSense API v2 spec:

| Original | Fixed |
|----------|-------|
| `/status/interface` | `/status/interfaces` |
| `/firewall/rule` | `/firewall/rules` |
| `/firewall/alias` | `/firewall/aliases` |
| `/diagnostics/log/firewall` | `/status/logs/firewall` |
| `/services` | `/status/services` |
| `/services/dhcpd/lease` | `/status/dhcp_server/leases` |

### Sort Order Parameter Fix

Changed sort order values from `"asc"`/`"desc"` to `"SORT_ASC"`/`"SORT_DESC"` per the API documentation.

### Stdio Mode Support

Added support for MCP stdio transport mode, enabling integration with Claude Code and other MCP-compatible clients:

- New `MCP_MODE` environment variable (`stdio` or `http`)
- When `MCP_MODE=stdio`, runs with `mcp.run(transport="stdio")`
- HTTP/uvicorn mode remains available as fallback

## Testing

Tested against:
- pfSense CE 2.8.1
- pfSense REST API v2 (jaredhendrickson13/pfsense-api)
- Claude Code MCP integration (stdio mode)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added selectable runtime mode: stdio or HTTP server via environment configuration.

* **Bug Fixes**
  * Corrected pfSense API endpoint targets for interfaces, firewall rules, aliases, logs, services, and DHCP leases.
  * Standardized sorting identifiers and updated default sort behavior to align with pfSense API v2.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->