### PR TITLE
docs: update README and all docs to post-1.0.0 state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,28 @@ All notable changes to the pfSense MCP Server will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+Post-1.0.0 bug fixes and quality improvements, all merged to `main`. No tool
+count change (still 327); test suite grew from 308 to 323.
+
+### Fixed
+
+- **All `delete_*` tools were non-functional** (#12, PR #9, PR #16). `httpx.AsyncClient.delete()` does not accept a `json=` kwarg, so every delete (firewall rules, NAT, aliases, DHCP mappings, etc.) raised `TypeError` before any HTTP traffic. DELETE now routes through `client.request("DELETE", ...)`, which supports the JSON body pfSense requires.
+- **`update_log_settings` could not enable remote syslog and silently dropped fields** (#13, PR #11). The wire-format keys `ipproto` and `reverse` were ignored by the API; renamed to `ipprotocol` and `reverseorder`. Added `enableremotelogging` (the master toggle), `logconfigchanges`, and the per-category remote-syslog toggles (`auth`, `portalauth`, `vpn`, `dpinger`, `hostapd`, `system`, `resolver`, `ppp`, `routing`, `ntpd`).
+- **`update_webgui_settings` could not change the WebGUI port** (#7). The pfSense REST API requires `port` as a string; the tool now accepts an `int` for ergonomics and coerces it to a string before sending.
+- **Log endpoints could hang until pfSense ran out of memory** (PR #6). Added a 10-second read-phase timeout and classification of read-phase failures (`ReadError`/`RemoteProtocolError`/`ReadTimeout`) into a clear, actionable message (upstream tracking: pfSense-pkg-RESTAPI#806), with docstring warnings on the log tools.
+- **Transient connectivity blip at launch killed the server** (PR #14). A momentary preflight failure before the stdio channel opens now logs a warning and starts anyway; individual tools surface connectivity errors when invoked.
+
+### Added
+
+- **IPv6 / dual-stack firewall rules** (PR #10). `create_firewall_rule_advanced` exposes an `ipprotocol` parameter (`inet`, `inet6`, `inet46`) with validation instead of hardcoding `inet`.
+- **uvx / pipx installation** (#8). Added a `pfsense-mcp-server` console entry point and setuptools package discovery, so the server can run without cloning the repository.
+
+### Changed
+
+- CI is green. The `ruff check src/ tests/` step had been failing on 80 pre-existing lint issues since before the 1.0.0 tag; all are resolved with no behavior change.
+
 ## [1.0.0] - 2026-03-26
 
 ### First Stable Release

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,59 @@
+# Contributing
+
+Thanks for helping improve the pfSense MCP Server. Real-world testing across
+diverse pfSense environments is especially valuable.
+
+## Development setup
+
+Requires **Python 3.11+** (`fastmcp` needs ≥3.10 and the package declares
+`requires-python = ">=3.11"`).
+
+```bash
+git clone https://github.com/gensecaihq/pfsense-mcp-server.git
+cd pfsense-mcp-server
+
+python3.11 -m venv .venv
+source .venv/bin/activate
+pip install --upgrade pip
+pip install -e ".[dev]"        # installs runtime + pytest, ruff
+```
+
+## Before you open a PR
+
+Run the full suite and the linter — CI runs both and must pass:
+
+```bash
+pytest -v                      # 323 tests
+pytest --cov=src               # with coverage
+ruff check src/ tests/         # lint (must be clean)
+```
+
+Add or update tests for any behavior you change. Tool tests live under
+`tests/tools/`; they patch `_make_request` via the `mock_client` /
+`mock_make_request` fixtures in `tests/conftest.py` and assert on the JSON body
+the tool sends — match that pattern.
+
+## Guidelines
+
+- **Mirror the pfSense REST API field names verbatim.** Several past bugs (#7,
+  #13) were silent field drops caused by a tool using a different key than the
+  API expects. When in doubt, check the API's OpenAPI schema / a live response.
+- **Respect the guardrail model.** New destructive tools must take `confirm`,
+  carry the right `ToolAnnotations`, and (for create/update) the `@rate_limited`
+  decorator. Risk classification lives in `src/guardrails.py`.
+- **Don't log secrets.** Sensitive parameters are redacted centrally; don't add
+  code paths that print raw request bodies or credentials.
+- Keep changes focused and match the style of the surrounding code.
+
+## Submitting
+
+1. Fork and create a feature branch.
+2. Make your change with tests; ensure `pytest` and `ruff check` pass.
+3. Open a PR describing the problem and the fix. If it addresses an issue,
+   reference it (e.g. `Closes #NN`).
+
+## Ideas
+
+Integration tests against real pfSense, additional package support (Snort,
+Suricata), an Ollama local-LLM bridge, and multi-instance management are all
+welcome.

--- a/PFSENSE_API_AUDIT.md
+++ b/PFSENSE_API_AUDIT.md
@@ -169,4 +169,4 @@ pfSense uses non-persistent array indices as object IDs. After any deletion, all
 | Helpers & validation | 1 | — |
 | **Total** | **34 tool files** | **327 tools** |
 
-**Tests: 308 passing**
+**Tests: 308 passing** _(v1.0.0 audit snapshot; current `main` is 323 passing after post-1.0.0 fixes — see [CHANGELOG](CHANGELOG.md))_

--- a/PFSENSE_API_INSTALLATION.md
+++ b/PFSENSE_API_INSTALLATION.md
@@ -71,7 +71,7 @@ Edit `.env` with your pfSense details. Example using Basic Auth (simplest):
 PFSENSE_URL=https://your-pfsense.local
 PFSENSE_USERNAME=admin
 PFSENSE_PASSWORD=your-password
-PFSENSE_VERSION=PLUS_24_11   # CE_2_8_0, CE_2_8_1, PLUS_24_11, PLUS_25_11
+PFSENSE_VERSION=PLUS_24_11   # CE_2_8_0, CE_2_8_1, CE_26_03, PLUS_24_11, PLUS_25_11
 AUTH_METHOD=basic
 VERIFY_SSL=false              # Set to true if using a trusted SSL certificate
 ```
@@ -103,10 +103,16 @@ Note: JWT auth obtains a token via `POST /api/v2/auth/jwt` using Basic Auth cred
 ## Test Connection
 
 ```bash
-python -m src.main
+python -m src.main          # from a clone
+# or, if installed as a package:
+pfsense-mcp-server
 ```
 
-The server tests the API connection on startup. If it fails, check:
+The server runs a preflight connection check on startup. If it fails, the
+server logs a warning and starts anyway (a transient network blip shouldn't
+prevent the MCP channel from opening) — individual tools then report the
+specific connectivity error when invoked. If tools consistently fail to reach
+pfSense, check:
 1. Is `PFSENSE_URL` correct and reachable from this machine?
 2. Is the REST API package installed and enabled at **System > REST API**?
 3. Is your chosen auth method enabled on the REST API settings page?

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 [![MCP 2025-11-25](https://img.shields.io/badge/MCP-2025--11--25-green.svg)](https://modelcontextprotocol.io)
 [![pfSense REST API](https://img.shields.io/badge/pfSense%20API-v2.7.3-orange.svg)](https://pfrest.org/)
-[![Tests](https://img.shields.io/badge/tests-308%20passing-brightgreen.svg)](#testing)
+[![Tests](https://img.shields.io/badge/tests-323%20passing-brightgreen.svg)](#testing)
 [![Tools](https://img.shields.io/badge/tools-327-blue.svg)](#what-you-can-do)
 
 > Manage your pfSense firewall with natural language. 327 tools. 9 layers of safety. One command to start.
@@ -28,7 +28,15 @@ Managing a pfSense firewall means clicking through web UI tabs, remembering fiel
 
 ## Quick Start
 
-**Prerequisites:** Python 3.10+, pfSense with [REST API v2 package](https://github.com/pfrest/pfSense-pkg-RESTAPI) installed
+**Prerequisites:** Python 3.11+, pfSense with [REST API v2 package](https://github.com/pfrest/pfSense-pkg-RESTAPI) installed
+
+**Option A — run without cloning (uvx):**
+
+```bash
+uvx --from git+https://github.com/gensecaihq/pfsense-mcp-server pfsense-mcp-server
+```
+
+**Option B — clone for development:**
 
 ```bash
 git clone https://github.com/gensecaihq/pfsense-mcp-server.git
@@ -38,7 +46,30 @@ cp .env.example .env
 # Edit .env: set PFSENSE_URL, AUTH_METHOD, and credentials
 ```
 
-**Connect to Claude Desktop** — add to `~/Library/Application Support/Claude/claude_desktop_config.json`:
+**Connect to Claude Desktop** — add to `~/Library/Application Support/Claude/claude_desktop_config.json`.
+
+Using the installed entry point (Option A):
+
+```json
+{
+  "mcpServers": {
+    "pfsense": {
+      "command": "uvx",
+      "args": ["--from", "git+https://github.com/gensecaihq/pfsense-mcp-server", "pfsense-mcp-server"],
+      "env": {
+        "PFSENSE_URL": "https://192.168.1.1",
+        "AUTH_METHOD": "basic",
+        "PFSENSE_USERNAME": "admin",
+        "PFSENSE_PASSWORD": "your-password",
+        "PFSENSE_VERSION": "CE_2_8_0",
+        "VERIFY_SSL": "false"
+      }
+    }
+  }
+}
+```
+
+Or running from a clone (Option B):
 
 ```json
 {
@@ -121,7 +152,7 @@ Response includes:
 You can also:
 - Pass `dry_run=True` to preview any destructive operation without executing
 - Pass `verify_descr="Allow HTTPS"` to verify you're deleting the right rule (guards against ID shifts)
-- Set `MCP_READ_ONLY=true` to expose only 118 read-only tools (search, get, diagnose)
+- Set `MCP_READ_ONLY=true` to expose only 130 read-only tools (search, get, diagnose)
 - Set `MCP_ALLOWED_TOOLS=search_firewall_rules,get_firewall_log` to restrict to specific tools
 
 ## Supported pfSense Versions
@@ -149,7 +180,8 @@ Three methods supported (configure in `.env`):
 
 **stdio** (default) — for Claude Desktop and Claude Code:
 ```bash
-python3 -m src.main
+python3 -m src.main          # from a clone
+pfsense-mcp-server           # via the installed console entry point (pip/uvx/pipx)
 ```
 
 **HTTP** — for remote access and multi-client setups:
@@ -202,7 +234,7 @@ Container security: non-root user (`mcp:1000`), read-only filesystem, all capabi
 ## Testing
 
 ```bash
-python3 -m pytest tests/ -v          # 308 tests
+python3 -m pytest tests/ -v          # 323 tests
 python3 -m pytest tests/ --cov=src   # with coverage
 ```
 
@@ -229,7 +261,7 @@ src/
   models.py            Data models
   middleware.py        HTTP auth + Origin validation
   tools/               34 tool modules (327 tools)
-tests/                 308 tests
+tests/                 323 tests
 ```
 
 ## Contributing
@@ -249,7 +281,13 @@ We need real-world testing across diverse pfSense environments. See [CONTRIBUTIN
 ## Acknowledgments
 
 - [jaredhendrickson13](https://github.com/jaredhendrickson13) / [pfrest](https://github.com/pfrest) — pfSense REST API v2 package
-- [JeremiahChurch](https://github.com/JeremiahChurch) — modular rewrite (PR #5)
+- [JeremiahChurch](https://github.com/JeremiahChurch) — modular rewrite (PR #5), log endpoint OOM safeguards (PR #6)
 - [shawnpetersen](https://github.com/shawnpetersen) — API v2 endpoint discovery (PR #3)
+- [aemitic](https://github.com/aemitic) — DELETE-body fix (PR #9), firewall `ipprotocol` for IPv6/dual-stack (PR #10), `logconfigchanges` (PR #11)
+- [hossamnagy](https://github.com/hossamnagy) — resilient startup on transient preflight failure (PR #14)
+- [bill-mccormick-dg](https://github.com/bill-mccormick-dg) — independent DELETE-body fix (PR #16)
+- [w1ld3r](https://github.com/w1ld3r) — DELETE and remote-syslog bug reports (#12, #13)
+- tvlc — WebGUI port type-mismatch report (#7)
+- [renanwilliam](https://github.com/renanwilliam) — uvx/pipx packaging request (#8)
 - [Netgate](https://netgate.com) — pfSense
 - [FastMCP](https://gofastmcp.com) — MCP framework


### PR DESCRIPTION
Brings the documentation in line with what's actually on `main` after the post-1.0.0 fixes (PRs #6/#9/#10/#11/#14/#16) and the CI/lint cleanup.

## Changes
- **README**: tests `308 → 323`, read-only tools `118 → 130`, Python `3.10+ → 3.11+`; added uvx/pipx install + run instructions (issue #8); credited the new contributors.
- **CHANGELOG**: new `Unreleased` section documenting every post-1.0.0 fix with issue/PR references.
- **PFSENSE_API_INSTALLATION**: documents the resilient-startup behavior (warn + start instead of `sys.exit` on preflight failure, PR #14); adds the installed entry-point command and `CE_26_03`.
- **PFSENSE_API_AUDIT**: notes the current test count beside the v1.0.0 snapshot.
- **CONTRIBUTING.md**: added (it was linked from the README but didn't exist).

## Accuracy
All figures were verified against the running server, not assumed:
- `327` total tools and `130` read-only tools — confirmed via `mcp.get_tools()` (and `MCP_READ_ONLY=true`).
- `52` destructive (HIGH+CRITICAL) and `112` rate-limited — confirmed via `classify_risk` and the `@rate_limited` count.
- `323` tests — confirmed via `pytest`.

Docs-only; no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)